### PR TITLE
refactor kernel cache and the way to get cuda context

### DIFF
--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "c10/util/Logging.h"  // use torch's logging
+#include "cuda.h"
 #include "torch/torch.h"
 
 namespace triton_jit {
@@ -104,4 +105,23 @@ struct triton_type : triton_type_helper<std::remove_cv_t<std::remove_reference_t
 std::filesystem::path get_script_dir();
 const char *get_gen_static_sig_script();
 const char *get_standalone_compile_script();
+void ensure_cuda_context();
+
+#define checkCudaErrors(err) __checkCudaErrors(err, __FILE__, __LINE__)
+
+// Error handling function using exceptions instead of exit()
+inline void __checkCudaErrors(CUresult code, const char *file, const int line) {
+  if (code != CUDA_SUCCESS) {
+    const char *error_string;
+    cuGetErrorString(code, &error_string);
+    fprintf(stderr,
+            "CUDA Driver API error = %04d from file <%s>, line %i. Detail: <%s>\n",
+            code,
+            file,
+            line,
+            error_string);
+    throw std::runtime_error(error_string);
+  }
+}
+
 }  // namespace triton_jit

--- a/include/triton_jit/triton_kernel.h
+++ b/include/triton_jit/triton_kernel.h
@@ -5,24 +5,9 @@
 #include <string>
 #include <unordered_map>
 #include "cuda.h"
+#include "triton_jit/jit_utils.h"
 
 namespace triton_jit {
-#define checkCudaErrors(err) __checkCudaErrors(err, __FILE__, __LINE__)
-
-// Error handling function using exceptions instead of exit()
-inline void __checkCudaErrors(CUresult code, const char *file, const int line) {
-  if (code != CUDA_SUCCESS) {
-    const char *error_string;
-    cuGetErrorString(code, &error_string);
-    fprintf(stderr,
-            "CUDA Driver API error = %04d from file <%s>, line %i. Detail: <%s>\n",
-            code,
-            file,
-            line,
-            error_string);
-    throw std::runtime_error(error_string);
-  }
-}
 
 class TritonKernel {
  private:
@@ -32,8 +17,10 @@ class TritonKernel {
   std::string kernel_name_;
   unsigned int shared_; /* amount of static shared memory per block (in bytes) required for the cubin*/
   unsigned int arch_;   /* cuda arch */
-  mutable std::unordered_map<CUdevice /*device id*/, CUmodule /*module*/>
-      modules_; /*loaded modules, possibly one per device if the arch matches*/
+
+  mutable CUmodule mod_;
+  mutable CUfunction fn_;
+  mutable bool loaded_ = false;
 
  public:
   TritonKernel(std::string_view dir, std::string_view kernel_name);
@@ -47,6 +34,6 @@ class TritonKernel {
 
  private:
   /* load cubin into a cumodule for a device */
-  void lazy_init_handle(CUdevice device_index) const;
+  void lazy_init_handle() const;
 };
 }  // namespace triton_jit

--- a/src/jit_utils.cpp
+++ b/src/jit_utils.cpp
@@ -62,4 +62,15 @@ std::filesystem::path get_home_directory() {
   }();
   return home_dir;
 }
+
+void ensure_cuda_context() {
+  CUcontext pctx;
+  checkCudaErrors(cuCtxGetCurrent(&pctx));
+  if (!pctx) {
+    CUdevice device_index;
+    checkCudaErrors(cuDeviceGet(&device_index, /*ordinal*/ 0));
+    checkCudaErrors(cuDevicePrimaryCtxRetain(&pctx, device_index));
+    checkCudaErrors(cuCtxSetCurrent(pctx));
+  }
+}
 }  // namespace triton_jit

--- a/src/triton_jit_function.cpp
+++ b/src/triton_jit_function.cpp
@@ -56,6 +56,7 @@ const TritonKernel& TritonJITFunction::get_kernel(std::string_view _signature,
                                                   int num_stages,
                                                   CUdevice device_index) const {
   std::string signature(_signature);
+  std::string key = fmt::format("{};{}", signature, device_index);
   // std::cout << "Standalone script to debug: \n"
   //           << fmt::format(
   //                  "python standalone_compile.py {} -n {} --device-id {} --num-warps {} --num-stages {} "
@@ -67,7 +68,7 @@ const TritonKernel& TritonJITFunction::get_kernel(std::string_view _signature,
   //                  num_stages,
   //                  signature)
   //           << std::endl;
-  auto pos = this->overloads_.find(signature);
+  auto pos = this->overloads_.find(key);
   if (pos == this->overloads_.end()) {
     // embed python
     namespace py = pybind11;
@@ -91,7 +92,7 @@ const TritonKernel& TritonJITFunction::get_kernel(std::string_view _signature,
     TritonKernel kernel(cache_dir, this->function_name_);
     LOG(INFO) << fmt::format("kernel_dir: {}", cache_dir);
     LOG(INFO) << fmt::format("kernel_name: {}", this->function_name_);
-    auto result = this->overloads_.insert({signature, kernel});
+    auto result = this->overloads_.insert({key, kernel});
     if (result.second) {
       pos = result.first;
     } else {

--- a/src/triton_kernel.cpp
+++ b/src/triton_kernel.cpp
@@ -23,13 +23,14 @@ TritonKernel::TritonKernel(std::string_view dir, std::string_view kernel_name)
   LOG(INFO) << fmt::format("TritonKernel Metadata loaded arch: {} shared: {}", this->arch_, this->shared_);
 }
 
-void TritonKernel::lazy_init_handle(CUdevice device_index) const {
-  if (modules_.count(device_index)) {
-    LOG(INFO) << fmt::format("cubin is loaded on device {}", device_index);
+void TritonKernel::lazy_init_handle() const {
+  if (this->loaded_) {
     return;
   }
 
   // check cuda arch
+  CUdevice device_index;
+  checkCudaErrors(cuCtxGetDevice(&device_index));
   int major = 0, minor = 0;
   checkCudaErrors(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device_index));
   checkCudaErrors(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device_index));
@@ -38,21 +39,44 @@ void TritonKernel::lazy_init_handle(CUdevice device_index) const {
     throw std::runtime_error("compute architecture mismatch!");
   }
 
-  CUmodule module;
+  // load module
   std::string cubin_path = fmt::format("{}/{}.cubin", this->dir_, this->kernel_name_);
   LOG(INFO) << fmt::format("Loading cubin {} into device {}", cubin_path, device_index);
-  checkCudaErrors(cuModuleLoad(&module, cubin_path.c_str()));
-  this->modules_.emplace(device_index, module);
+  checkCudaErrors(cuModuleLoad(&this->mod_, cubin_path.c_str()));
+
+  // get function
+  checkCudaErrors(cuModuleGetFunction(&this->fn_, this->mod_, this->kernel_name_.c_str()));
+
+  // check required shared memory does not exceeds max shared memory per block
   int shared_optin;
-  CUdevice d;
-  checkCudaErrors(cuCtxGetDevice(&d));
-  cuDeviceGetAttribute(&shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, d);
+  cuDeviceGetAttribute(&shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, device_index);
   if (this->shared_ > shared_optin) {
     throw std::runtime_error(
         fmt::format("Out0fResources: Requested shared memory ({}) bytes exceeds GPU's maximum ({}) bytes.",
                     this->shared_,
                     shared_optin));
   }
+
+  // increase shared memory if required
+  if (this->shared_ > 49152 && shared_optin > 49152) {
+    LOG(INFO) << fmt::format(
+        "Condition met: this->shared_ ={} && shared_optin = {}. Setting CU_FUNC_CACHE_PREFER_SHARED.",
+        this->shared_,
+        shared_optin);
+    checkCudaErrors(cuFuncSetCacheConfig(this->fn_, CU_FUNC_CACHE_PREFER_SHARED));
+    int shared_total, shared_static;
+    checkCudaErrors(cuDeviceGetAttribute(&shared_total,
+                                         CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
+                                         device_index));
+    checkCudaErrors(cuFuncGetAttribute(&shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, this->fn_));
+    LOG(INFO) << fmt::format("current shared memory total {}", shared_total);
+    LOG(INFO) << fmt::format("current shared memory static {}", shared_static);
+    checkCudaErrors(cuFuncSetAttribute(this->fn_,
+                                       CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                                       shared_optin - shared_static));
+    LOG(INFO) << fmt::format("shared memory to add {}", shared_optin - shared_static);
+  }
+  this->loaded_ = true;
 }
 
 // consider using a variadic template
@@ -63,54 +87,19 @@ void TritonKernel::launch(unsigned int grid_x,
                           CUstream stream,
                           void** args) const {
   // get the context associated with the stream
-  CUcontext ctx;
-  checkCudaErrors(cuStreamGetCtx(stream, &ctx));
-  checkCudaErrors(cuCtxSetCurrent(ctx));
-  CUdevice d;
-  checkCudaErrors(
-      cuCtxGetDevice(&d));  // device management is done with torch, assume one CUcontext per device
-  this->lazy_init_handle(d);
-  // TODO: some kernels need to be launched via cuLaunchKernelEx, add that later?
-  CUfunction f;
-  checkCudaErrors(
-      cuModuleGetFunction(&f,
-                          this->modules_.at(d),
-                          this->kernel_name_.c_str()));  // maybe check CUfunction instead of CUmodule?
-  int shared_optin;
-  cuDeviceGetAttribute(&shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, d);
-  int shared_memory = this->shared_;
-  if (this->shared_ > 49152 && shared_optin > 49152) {
-    LOG(INFO) << fmt::format(
-        "Condition met: this->shared_ ={} && shared_optin = {}. Setting CU_FUNC_CACHE_PREFER_SHARED.",
-        this->shared_,
-        shared_optin);
-    checkCudaErrors(cuFuncSetCacheConfig(f, CU_FUNC_CACHE_PREFER_SHARED));
-    int shared_total, shared_static;
-    checkCudaErrors(
-        cuDeviceGetAttribute(&shared_total, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR, d));
-    checkCudaErrors(cuFuncGetAttribute(&shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, f));
-    LOG(INFO) << fmt::format("current shared memory total {}", shared_total);
-    LOG(INFO) << fmt::format("current shared memory static {}", shared_static);
-    checkCudaErrors(
-        cuFuncSetAttribute(f, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, shared_optin - shared_static));
-    shared_memory = shared_optin - shared_static;
-    LOG(INFO) << fmt::format("shared memory to add {}", shared_memory);
-  }
+  this->lazy_init_handle();
+
   LOG(INFO) << "cuLaunchKernel";
-  checkCudaErrors(cuLaunchKernel(f,
-                                 /*grid*/
-                                 grid_x,
+  checkCudaErrors(cuLaunchKernel(this->fn_,
+                                 /*grid*/ grid_x,
                                  grid_y,
                                  grid_z,
-                                 /*block*/
-                                 32 * num_warps,
+                                 /*block*/ 32 * num_warps,
                                  1,
                                  1,
-                                 /*shared & stream*/
-                                 shared_memory,
-                                 stream,
-                                 /*args*/
-                                 args,
+                                 /*shared & stream*/ this->shared_,
+                                 /*stream*/ stream,
+                                 /*args*/ args,
                                  nullptr));
 }
 }  // namespace triton_jit


### PR DESCRIPTION
1. Refactor TritonJITFunction's overloads. Now the device id is a part of the key.
2. Refactor TritonKernel's. Now it nolonger has a device_id -> CUmodule mapping. The CUmodule & CUfunction is cached in the TritonKernel itself with a flag loaded to indicate whether it is loaded.
3. Refactor the way to get CUDA context.