### PR TITLE
Fix attribute descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is the main facilities for calling jit functions from C++, which can be use
 
 ## Usage
 
-The basic usage of this library is via `TritonJITFunction`. First, get a `TritonJITFunction` via `TritonJITFunction::getInstance(source_path, function_name)`. Then call it.
+The basic usage of this library is via `TritonJITFunction`. First, get a `TritonJITFunction` via `TritonJITFunction::get_instance(source_path, function_name)`. Then call it.
 
 The `operator()` of `TritonJITFunction` is a variadic template. The arguments consist of 2 parts.
 
@@ -81,7 +81,7 @@ at::Tensor add_tensor(const at::Tensor &a_, const at::Tensor &b_) {
   at::Tensor out = at::empty(a.sizes(), at::TensorOptions().dtype(out_dtype).device(a.device()));
 
   const triton_jit::TritonJITFunction &f =
-      triton_jit::TritonJITFunction::getInstance("add.py", "binary_pointwise_kernel");
+      triton_jit::TritonJITFunction::get_instance("add.py", "binary_pointwise_kernel");
 
   // add utility to build this automatically
   int64_t tile_size = 1024;

--- a/scripts/standalone_compile.py
+++ b/scripts/standalone_compile.py
@@ -143,8 +143,8 @@ def _compile_a_kernel(
     hints = {k: v for k, v in hints.items() if v is not None}
     for h in hints.values():
         assert h in [1, 16], f"Only 1 and 16 are valid hints, got {h}"
-    divisible_by_16 = [i for i, h in hints.items() if h == 16]
-    equal_to_1 = [i for i, h in hints.items() if h == 1]
+    divisible_by_16 = tuple(i for i, h in hints.items() if h == 16)
+    equal_to_1 = tuple(i for i, h in hints.items() if h == 1)
 
     if triton_version.major == 3 and triton_version.minor == 1:
         attrs = triton.compiler.AttrsDescriptor(


### PR DESCRIPTION
1. Fix attribute descriptor: use tuple instead of list to hold arg indices, since some triton backend check the type of components in attribute descriptor and distinguish between list and tuple;
2. update sample code in doc